### PR TITLE
NFA implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ Example configuration files for any automatons that have been implemented so far
 ### DFA
 - `dfa01.json`: Accepts all strings over $\Sigma = \{a, b\}$ which have `aa` as a substring
 - `dfa02.json`: Accepts all strings over $\Sigma = \{0, 1\}$ which have odd number of 1's and odd number of 0's.
+
+### NFA
+- `nfa01.json`: Accepts all strings over $\Sigma = \{a, b\}$ which end in `ab`
+- `nfa02.json`: Accepts all strings over $\Sigma = \{a, b\}$ which start with `a`
+- `nfa02.json`: Accepts all strings that match the regular expression $\regex{(b)^\ast a}$

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Example configuration files for any automatons that have been implemented so far
 ### NFA
 - `nfa01.json`: Accepts all strings over $\Sigma = \{a, b\}$ which end in `ab`
 - `nfa02.json`: Accepts all strings over $\Sigma = \{a, b\}$ which start with `a`
-- `nfa02.json`: Accepts all strings that match the regular expression $\regex{(b)^\ast a}$
+- `nfa02.json`: Accepts all strings that match the regular expression $(b)^\ast a$

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ I got the idea while playing around with [JFLAP](https://www.jflap.org/).
 ## Roadmap
 List of features I'd like to implement (highly unlikely):
 - [x] Deterministic Finite State Automata
-- [ ] Non-deterministic Finite State Automata
+- [x] Non-deterministic Finite State Automata
 - [ ] Pushdown Automata
 - [ ] Simple Turing Machines
 - [ ] Visualize automata described by a config file

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -54,16 +54,20 @@ impl ReadFAConfig for DFA {
 
         let mut transitions = vec![vec![vec![]; states.len()]; states.len()];
         for (idx, transition) in config.transitions.into_iter().enumerate() {
-            if !config.alphabet.contains(&transition.on) {
-                panic!("Error reading configuration: Character {} not present in given alphabet for DFA", transition.on);
+            if let Some(on) = &transition.on {
+                if !config.alphabet.contains(on) {
+                    panic!("Error reading configuration: Character {} not present in given alphabet for DFA", on);
+                } else {
+                    let y = state_to_idx.get(&transition.from).expect(
+                    format!("Error reading configuration: State {} not found in set of all states while parsing transition {}", transition.from, idx + 1).as_str()
+                );
+                    let x = state_to_idx.get(&transition.to).expect(
+                    format!("Error reading configuration: State {} not found in set of all states while parsing transition {}", transition.from, idx + 1).as_str()
+                );
+                    transitions[*y][*x].push(on.chars().next().expect("Error reading configuration: exhausted string iterator while parsing transitions"));
+                }
             } else {
-                let y = state_to_idx.get(&transition.from).expect(
-                    format!("Error reading configuration: State {} not found in set of all states while parsing transition {}", transition.from, idx + 1).as_str()
-                );
-                let x = state_to_idx.get(&transition.to).expect(
-                    format!("Error reading configuration: State {} not found in set of all states while parsing transition {}", transition.from, idx + 1).as_str()
-                );
-                transitions[*y][*x].push(transition.on.chars().next().expect("Error reading configuration: exhausted string iterator while parsing transitions"));
+                panic!("Error reading configuration: Null transition not allowed in DFAs");
             }
         }
 

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -1,29 +1,6 @@
-use crate::traits::Acceptor;
-use serde::{Deserialize, Serialize};
+use crate::fa::{Acceptor, FAConfig, ReadFAConfig, State};
 use std::collections::{HashMap, HashSet};
-use std::{fs, path::PathBuf};
-
-#[derive(Debug, Deserialize, Serialize)]
-struct DFAConfig {
-    states: Vec<String>,
-    initial_state: String,
-    final_states: Vec<String>,
-    alphabet: HashSet<String>,
-    transitions: Vec<Transition>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct Transition {
-    from: String,
-    to: String,
-    on: String,
-}
-
-#[derive(Debug, Hash, PartialEq, Eq)]
-struct State {
-    name: String,
-    index: usize,
-}
+use std::path::PathBuf;
 
 #[derive(Debug)]
 pub struct DFA {
@@ -34,21 +11,13 @@ pub struct DFA {
     transitions: Vec<Vec<Vec<char>>>, // adjacency matrix for the state graph
 }
 
-impl DFAConfig {
-    pub fn from_file(path: PathBuf) -> Self {
-        let s = fs::read_to_string(path).unwrap();
-        let parsed: DFAConfig = serde_json::from_str(s.as_str()).unwrap();
-        parsed
-    }
-}
-
-impl DFA {
-    pub fn from_file(path: PathBuf) -> Self {
-        let config = DFAConfig::from_file(path);
+impl ReadFAConfig for DFA {
+    fn from_file(path: PathBuf) -> Self {
+        let config = FAConfig::from_file(path);
         Self::from_config(config)
     }
 
-    fn from_config(config: DFAConfig) -> Self {
+    fn from_config(config: FAConfig) -> Self {
         let mut states = HashMap::new();
         let mut state_to_idx: HashMap<String, usize> = HashMap::new();
         let mut initial_state: usize = usize::MAX;

--- a/src/fa.rs
+++ b/src/fa.rs
@@ -16,7 +16,7 @@ pub struct FAConfig {
 pub struct Transition {
     pub from: String,
     pub to: String,
-    pub on: String,
+    pub on: Option<String>,
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]

--- a/src/fa.rs
+++ b/src/fa.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::{fs, path::PathBuf};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FAConfig {
+    /// Describes a finite state automaton.
+    pub states: Vec<String>,
+    pub initial_state: String,
+    pub final_states: Vec<String>,
+    pub alphabet: HashSet<String>,
+    pub transitions: Vec<Transition>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Transition {
+    pub from: String,
+    pub to: String,
+    pub on: String,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+pub struct State {
+    pub name: String,
+    pub index: usize,
+}
+
+impl FAConfig {
+    pub fn from_file(path: PathBuf) -> Self {
+        let s = fs::read_to_string(path).unwrap();
+        let parsed: FAConfig = serde_json::from_str(s.as_str()).unwrap();
+        parsed
+    }
+}
+
+pub trait Acceptor {
+    /// All acceptor automata will implement this trait.
+    fn test_string(&self, s: String) -> bool;
+}
+
+pub trait ReadFAConfig {
+    fn from_config(config: FAConfig) -> Self;
+    fn from_file(path: PathBuf) -> Self
+    where
+        Self: Sized,
+    {
+        let config = FAConfig::from_file(path);
+        Self::from_config(config)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
 mod dfa;
-mod traits;
-use std::path::PathBuf;
+mod fa;
+mod nfa;
 
 use clap::{builder::PossibleValue, Parser, ValueEnum};
 use dfa::DFA;
-use traits::Acceptor;
+use fa::{Acceptor, ReadFAConfig};
+use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 struct Arguments {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod nfa;
 use clap::{builder::PossibleValue, Parser, ValueEnum};
 use dfa::DFA;
 use fa::{Acceptor, ReadFAConfig};
+use nfa::NFA;
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
@@ -22,17 +23,21 @@ struct Arguments {
 #[derive(Copy, Clone, Debug)]
 enum AutomatonType {
     DFA,
+    NFA,
 }
 
 impl ValueEnum for AutomatonType {
     fn value_variants<'a>() -> &'a [Self] {
-        &[AutomatonType::DFA]
+        &[AutomatonType::DFA, AutomatonType::NFA]
     }
 
     fn to_possible_value<'a>(&self) -> Option<PossibleValue> {
         Some(match self {
             AutomatonType::DFA => {
                 PossibleValue::new("dfa").help("Deterministic Finite State Automata")
+            }
+            AutomatonType::NFA => {
+                PossibleValue::new("nfa").help("Non-deterministic Finite State Automata")
             }
         })
     }
@@ -43,6 +48,15 @@ fn main() {
     match args.automaton {
         AutomatonType::DFA => {
             let machine = DFA::from_file(args.file);
+            let result = if machine.test_string(args.string) {
+                "Accepted"
+            } else {
+                "Rejected"
+            };
+            println!("{}", result);
+        }
+        AutomatonType::NFA => {
+            let machine = NFA::from_file(args.file);
             let result = if machine.test_string(args.string) {
                 "Accepted"
             } else {

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -1,0 +1,103 @@
+use crate::fa::{Acceptor, FAConfig, ReadFAConfig, State};
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct NFA {
+    /// Evaluate and validate the DFA described by a given DFAConfig
+    states: HashMap<usize, State>,
+    initial_state: usize,
+    final_states: HashSet<usize>,
+    transitions: Vec<Vec<Vec<char>>>, // adjacency matrix for the state graph
+}
+
+impl ReadFAConfig for NFA {
+    fn from_file(path: PathBuf) -> Self {
+        let config = FAConfig::from_file(path);
+        Self::from_config(config)
+    }
+
+    fn from_config(config: FAConfig) -> Self {
+        let mut states = HashMap::new();
+        let mut state_to_idx: HashMap<String, usize> = HashMap::new();
+        let mut initial_state: usize = usize::MAX;
+
+        for (idx, name) in config.states.into_iter().enumerate() {
+            states.insert(
+                idx,
+                State {
+                    name: name.clone(),
+                    index: idx,
+                },
+            );
+            state_to_idx.insert(name.clone(), idx);
+            if name == config.initial_state {
+                initial_state = idx;
+            }
+        }
+
+        if initial_state == usize::MAX {
+            panic!("Error reading configuration: Initial state not present in set of all states");
+        }
+
+        let mut final_states = HashSet::new();
+        for name in config.final_states.into_iter() {
+            if let Some(s) = state_to_idx.get(&name) {
+                final_states.insert(s.to_owned());
+            } else {
+                panic!(
+                    "Error reading configuration: Final state {} not present in set of all states",
+                    name
+                );
+            }
+        }
+
+        let mut transitions = vec![vec![vec![]; states.len()]; states.len()];
+        for (idx, transition) in config.transitions.into_iter().enumerate() {
+            if !config.alphabet.contains(&transition.on) {
+                panic!("Error reading configuration: Character {} not present in given alphabet for DFA", transition.on);
+            } else {
+                let y = state_to_idx.get(&transition.from).expect(
+                    format!("Error reading configuration: State {} not found in set of all states while parsing transition {}", transition.from, idx + 1).as_str()
+                );
+                let x = state_to_idx.get(&transition.to).expect(
+                    format!("Error reading configuration: State {} not found in set of all states while parsing transition {}", transition.from, idx + 1).as_str()
+                );
+                transitions[*y][*x].push(transition.on.chars().next().expect("Error reading configuration: exhausted string iterator while parsing transitions"));
+            }
+        }
+
+        return NFA {
+            states,
+            initial_state,
+            final_states,
+            transitions,
+        };
+    }
+}
+
+impl Acceptor for NFA {
+    fn test_string(&self, s: String) -> bool {
+        let chars = s.chars().collect::<Vec<_>>();
+        backtrack(self, self.initial_state, 0, &chars)
+    }
+}
+
+fn backtrack(nfa: &NFA, current_state: usize, current_char: usize, chars: &Vec<char>) -> bool {
+    if current_char == chars.len() {
+        let a = nfa.final_states.contains(&current_state);
+        return a;
+    }
+    let mut result = false;
+    for (idx, neighborhood) in nfa.transitions[current_state].iter().enumerate() {
+        if neighborhood.is_empty() {
+            continue;
+        }
+        // TODO: this doesn't account for null transitions yet!
+        if neighborhood.contains(&chars[current_char]) {
+            // if ANY of the paths result in an acceptance, the string is accepted
+            result = result | backtrack(nfa, idx, current_char + 1, chars);
+        }
+    }
+    result
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,3 +1,0 @@
-pub trait Acceptor {
-    fn test_string(&self, s: String) -> bool;
-}

--- a/test_configs/nfa01.json
+++ b/test_configs/nfa01.json
@@ -1,0 +1,28 @@
+{
+    "states": ["q0", "q1", "q2"],
+    "initial_state": "q0",
+    "final_states": ["q2"],
+    "alphabet": ["a", "b"],
+    "transitions": [
+        {
+            "from": "q0",
+            "to": "q0",
+            "on": "a"
+        },
+        {
+            "from": "q0",
+            "to": "q0",
+            "on": "b"
+        },
+        {
+            "from": "q0",
+            "to": "q1",
+            "on": "a"
+        },
+        {
+            "from": "q1",
+            "to": "q2",
+            "on": "b"
+        }
+    ]
+}

--- a/test_configs/nfa02.json
+++ b/test_configs/nfa02.json
@@ -1,0 +1,23 @@
+{
+    "states": ["q0", "q1"],
+    "initial_state": "q0",
+    "final_states": ["q1"],
+    "alphabet": ["a", "b"],
+    "transitions": [
+        {
+            "from": "q0",
+            "to": "q1",
+            "on": "a"
+        },
+        {
+            "from": "q1",
+            "to": "q1",
+            "on": "a"
+        },
+        {
+            "from": "q1",
+            "to": "q1",
+            "on": "b"
+        }
+    ]
+}

--- a/test_configs/nfa03.json
+++ b/test_configs/nfa03.json
@@ -1,0 +1,38 @@
+{
+    "states": ["q0", "q1", "q2", "q3", "q4"],
+    "initial_state": "q0",
+    "final_states": ["q4"],
+    "alphabet": ["a", "b"],
+    "transitions": [
+        {
+            "from": "q0",
+            "to": "q1",
+            "on": null
+        },
+        {
+            "from": "q0",
+            "to": "q3",
+            "on": null
+        },
+        {
+            "from": "q1",
+            "to": "q2",
+            "on": "b"
+        },
+        {
+            "from": "q2",
+            "to": "q1",
+            "on": null
+        },
+        {
+            "from": "q2",
+            "to": "q3",
+            "on": null
+        },
+        {
+            "from": "q3",
+            "to": "q4",
+            "on": "a"
+        }
+    ]
+}


### PR DESCRIPTION
Implements evaluating strings on NFAs and NFAs with null transitions.
The unicode character for epsilon is used to represent a null transition.
TODO: profile the entire codebase. I have a feeling this backtracking may not scale well for large NFAs with many states that would create deep search trees.